### PR TITLE
Switch to one term per year

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,4 @@ gem "open-uri-cached"
 gem "fuzzy_match"
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'
 gem 'scraped_page_archive'
+gem 'combine_popolo_memberships', '~> 0.2.0', git: "https://github.com/everypolitician/combine_popolo_memberships.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,10 @@
 GIT
+  remote: https://github.com/everypolitician/combine_popolo_memberships.git
+  revision: 0a18a0defb11cf08f59f7f6cdc8de898227cbe89
+  specs:
+    combine_popolo_memberships (0.2.0)
+
+GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
@@ -63,6 +69,7 @@ PLATFORMS
 
 DEPENDENCIES
   colorize
+  combine_popolo_memberships (~> 0.2.0)!
   execjs
   fuzzy_match
   nokogiri
@@ -76,4 +83,4 @@ RUBY VERSION
    ruby 2.0.0p353
 
 BUNDLED WITH
-   1.12.5
+   1.13.6


### PR DESCRIPTION
The terms of senators are six years long in the Argentine Senate, but
only a third of those are relected every two years.  We've decided that
it will be easier to manage this if we artificially say that terms are
yearly, like the sessions of the National Congress of Argentina (of
which the senate is the upper house).