### PR TITLE
Scrape names in first-name last-name order

### DIFF
--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -1,0 +1,21 @@
+require 'scraped'
+
+class MemberPage < Scraped::HTML
+  field :name do
+    "#{given_name} #{family_name}"
+  end
+
+  field :given_name do
+    member_info.at_xpath('./text()').text.tidy
+  end
+
+  field :family_name do
+    member_info.at_xpath('./span').text.tidy
+  end
+
+  private
+
+  def member_info
+    noko.at_xpath('//div[@class="col-sm-12 col-md-5"]/div')
+  end
+end

--- a/scraper.rb
+++ b/scraper.rb
@@ -35,13 +35,20 @@ terms = (2015..Date.today.year).map do |year|
 end
 
 def scrape_list(url)
-  MembersList.new(response: Scraped::Request.new(url: url).response).members
+  MembersList.new(response: Scraped::Request.new(url: url).response)
+             .members
+             .map(&:to_h)
+             .map do |member|
+              member.merge(MemberPage.new(
+                response: Scraped::Request.new(url: member[:source]).response
+                ).to_h)
+             end
 end
 
 memberships_from_page = scrape_list('http://www.senado.gov.ar/senadores/listados/listaSenadoRes')
 
 data = CombinePopoloMemberships.combine(
-  id: memberships_from_page.map(&:to_h),
+  id: memberships_from_page,
   term: terms,
 )
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -16,7 +16,7 @@ require_rel 'lib'
 
 class String
   def tidy
-    self.gsub(/[[:space:]]+/, ' ').strip
+    gsub(/[[:space:]]+/, ' ').strip
   end
 end
 
@@ -30,7 +30,7 @@ terms = (2015..Date.today.year).map do |year|
   {
     id: year,
     start_date: Date.new(year, 3, 1).to_s,
-    end_date: Date.new(year, 11, 30).to_s,
+    end_date: Date.new(year, 11, 30).to_s
   }
 end
 
@@ -39,9 +39,9 @@ def scrape_list(url)
              .members
              .map(&:to_h)
              .map do |member|
-              member.merge(MemberPage.new(
-                response: Scraped::Request.new(url: member[:source]).response
-                ).to_h)
+               member.merge(MemberPage.new(
+                 response: Scraped::Request.new(url: member[:source]).response
+               ).to_h)
              end
 end
 
@@ -49,7 +49,7 @@ memberships_from_page = scrape_list('http://www.senado.gov.ar/senadores/listados
 
 data = CombinePopoloMemberships.combine(
   id: memberships_from_page,
-  term: terms,
+  term: terms
 )
 
 ScraperWiki.save_sqlite([:id, :term], data)


### PR DESCRIPTION
Member names are stored in our existing data in _first-name_ _last-name_ order.

![pasted image at 2016_12_01 03_20 pm](https://cloud.githubusercontent.com/assets/4107953/20831196/d055fef0-b87b-11e6-957d-df8154895df1.png)


The scraper is currently capturing them in sort order (_last-name_ _first-name_), and so it appears that the members are changing names:

`f003f504-1b4e-411a-80dd-fa08f8ebd306: Ana Claudia Almirón → Almirón Ana Claudia`

This PR fixes that. The scraper previously only scraped member details from the member list page. This PR adds the `MemberPage` class. The names of each member (`:given_name`, `:family_name`, `:name`) are scraped from the individual member pages.

## [Scraper Change checklist](https://github.com/everypolitician/everypolitician/wiki/Scraper-Change-checklist)
* [x] 1. scraper is on Morph.io under the "everypolitician-scrapers" group?
* [x] 2. scraper's GitHub "Website" link points at morph.io page?
* [x] 3. scraper is set to auto-run?
* [x] 4. scraper is archiving?
* [x] 5. legislature has a scraper webhook set?